### PR TITLE
set default method for fetch api

### DIFF
--- a/src/utils/faker.js
+++ b/src/utils/faker.js
@@ -42,7 +42,7 @@ class Faker {
     this.apiList[key].skip = !this.apiList[key].skip;
   };
 
-  matchMock = (url, method) => {
+  matchMock = (url, method = "GET") => {
     const key = this.getKey(url, method);
     if (this.apiList[key] && !this.apiList[key].skip) {
       return this.apiList[key];


### PR DESCRIPTION
Hi! I found an issue with the package. The default behaviour for `fetch` is, you can set up only the first parameter and in that case, the `GET` request will be called. Unfortunately, the current version of the module always expects some method parameter.

This pull request should fix it. Thank you!