### PR TITLE
fix: allow second arg of fetch to be undefined

### DIFF
--- a/src/utils/request.js
+++ b/src/utils/request.js
@@ -1,4 +1,4 @@
-export function Request(input, options) {
+export function Request(input, options = {}) {
     if (typeof input === 'object') {
         this.method = options.method || input.method || 'GET';
         this.url = input.url;


### PR DESCRIPTION
Like Request(), the second argument of fetch() is optional. Avoid property error in this case by
defaulting options to an empty object.

Fixes #39 