### PR TITLE
Added query param search

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "@storybook/addons": "^6.2.9",
     "@storybook/react": "^6.2.9",
+    "faker": "^5.5.3",
     "mock-xmlhttprequest": "^7.0.3",
     "path-to-regexp": "^6.2.0",
     "react-json-editor-ajrm": "^2.5.13"

--- a/stories/example.stories.js
+++ b/stories/example.stories.js
@@ -1,9 +1,22 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import axios from 'axios';
 import { storiesOf } from '@storybook/react';
 import { UserGuide } from './components/user-guide';
 import withMock from '../dist';
+import * as faker from 'faker';
+
+const fakeyMcFakeData = Array.from(Array(50)).map(() => {
+    const id = faker.random.uuid();
+    const first_name = faker.name.firstName();
+    const last_name = faker.name.firstName();
+    return {
+        id,
+        email: `${first_name.toLowerCase()}.${last_name.toLowerCase()}@fake-email.com`,
+        first_name,
+        last_name,
+    };
+});
 
 const containerStyles = {
     display: 'flex',
@@ -39,6 +52,14 @@ const buttonStyles = {
     padding: '12px',
     margin: '12px 0',
     color: 'white',
+};
+
+const inputStyles = {
+    border: '1px solid #127ec3',
+    borderRadius: '3px',
+    fontSize: '15px',
+    padding: '12px',
+    margin: '12px 0 12px 10px',
 };
 
 const callFetch = async () => {
@@ -81,7 +102,6 @@ const callAxios = async () => {
     let data = null;
     let error = null;
     let status = null;
-
     try {
         const response = await axios.get(
             'https://jsonplaceholder.typicode.com/todos/1'
@@ -91,6 +111,63 @@ const callAxios = async () => {
     } catch (err) {
         error = err.response.data;
         status = err.response.status;
+    }
+    return {
+        data,
+        error,
+        status,
+    };
+};
+
+const callSearchAxios = async ({ search = '' }) => {
+    let data = null;
+    let error = null;
+    let status = null;
+    try {
+        const response = await axios.get(
+            `https://jsonplaceholder.typicode.com/todos?search=${search}&lite=true`
+        );
+        data = response.data;
+        status = response.status;
+    } catch (err) {
+        error = err.response.data;
+        status = err.response.status;
+    }
+    return {
+        data,
+        error,
+        status,
+    };
+};
+
+const callSearchFetch = async ({ search = '' }) => {
+    let data = null;
+    let error = null;
+    let status = null;
+
+    try {
+        const response = await fetch(
+            `https://jsonplaceholder.typicode.com/todos?search=${search}&lite=true`,
+            {
+                headers: {
+                    Accept: 'application/json',
+                    'Content-Type': 'application/json',
+                },
+                method: 'GET',
+            }
+        );
+        const responseData = await response.json();
+
+        if (response.ok) {
+            data = responseData;
+        } else {
+            error = responseData;
+        }
+        status = response.status;
+    } catch (err) {
+        // eslint-disable-next-line no-console
+        console.log(err);
+        error = err;
     }
     return {
         data,
@@ -144,12 +221,90 @@ const MockExample = ({ title, onRequest }) => {
     );
 };
 
+const MockSearchExample = ({ title, onRequest }) => {
+    const [response, setResponse] = useState({});
+    const [loading, setLoading] = useState(false);
+    const [search, setSearch] = useState('');
+
+    const requestForData = async (search) => {
+        setLoading(true);
+        const fetchResponse = await onRequest({ search });
+        setLoading(false);
+        setResponse(fetchResponse);
+    };
+    const { data, error, status } = response;
+
+    const handleSearchChange = (event) => {
+        setSearch(event.target.value);
+        requestForData(event.target.value);
+    };
+    useEffect(() => {
+        requestForData(search);
+    }, []);
+    return (
+        <div style={containerStyles}>
+            <div>
+                <div style={headerStyles}>
+                    <h2>{title}</h2>
+                    <input
+                        style={inputStyles}
+                        value={search}
+                        onChange={handleSearchChange}
+                    />
+                </div>
+                {loading ? (
+                    <div style={responseContainerStyles}>Loading...</div>
+                ) : (
+                    <div style={responseContainerStyles}>
+                        {status && <div>Status: {status}</div>}
+                        {error && (
+                            <div style={errorContainerStyles}>
+                                Error:
+                                <pre>{JSON.stringify(error, null, 2)}</pre>
+                            </div>
+                        )}
+                        {data && (
+                            <div>
+                                Response:
+                                <pre>{JSON.stringify(data, null, 2)}</pre>
+                            </div>
+                        )}
+                    </div>
+                )}
+            </div>
+            <UserGuide />
+        </div>
+    );
+};
+
 MockExample.propTypes = {
     title: PropTypes.string,
     onRequest: PropTypes.func,
 };
 
 const mockData = [
+    {
+        url: 'https://jsonplaceholder.typicode.com/todos?search=:search&lite=true',
+        method: 'GET',
+        status: 200,
+        delay: 0,
+        response: fakeyMcFakeData,
+
+        searchFunc: (data, searchParamEntries) => {
+            return searchParamEntries.search === ''
+                ? data
+                : data.filter(({ first_name, last_name }) => {
+                      return (
+                          first_name
+                              .toLowerCase()
+                              .startsWith(searchParamEntries.search) ||
+                          last_name
+                              .toLowerCase()
+                              .startsWith(searchParamEntries.search)
+                      );
+                  });
+        },
+    },
     {
         url: 'https://jsonplaceholder.typicode.com/todos/:id',
         method: 'GET',
@@ -171,5 +326,25 @@ storiesOf('Storybook-addon-mock', module)
     .add(
         'Axios request',
         () => <MockExample title="Axios(XHR)" onRequest={callAxios} />,
+        { mockData }
+    )
+    .add(
+        'Axios Search request',
+        () => (
+            <MockSearchExample
+                title="Axios Search"
+                onRequest={callSearchAxios}
+            />
+        ),
+        { mockData }
+    )
+    .add(
+        'Fetch Search request',
+        () => (
+            <MockSearchExample
+                title="Fetch Search"
+                onRequest={callSearchFetch}
+            />
+        ),
         { mockData }
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -5708,6 +5708,11 @@ extglob@^2.0.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
+faker@^5.5.3:
+  version "5.5.3"
+  resolved "https://registry.yarnpkg.com/faker/-/faker-5.5.3.tgz#c57974ee484431b25205c2c8dc09fda861e51e0e"
+  integrity sha512-wLTv2a28wjUyWkbnX7u/ABZBkUkIF2fCd73V6P2oFqEGEktDfzWx4UxrSqtPRw0xPRAcjeAOIiJWqZm3pP4u3g==
+
 fast-deep-equal@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"


### PR DESCRIPTION
Used faker to generate a list of 50 fake users `fakeyMcFakeData`

Extended the existing param handling and added a searchFunc to the mock data 

```
 {
        url: 'https://jsonplaceholder.typicode.com/todos?search=:search&lite=true',
        method: 'GET',
        status: 200,
        delay: 0,
        response: fakeyMcFakeData,
        searchFunc: (data, searchParamEntries) => {
            return searchParamEntries.search === ''
                ? data
                : data.filter(({ first_name, last_name }) => {
                      return (
                          first_name
                              .toLowerCase()
                              .startsWith(searchParamEntries.search) ||
                          last_name
                              .toLowerCase()
                              .startsWith(searchParamEntries.search)
                      );
                  });
        },
    },

```
Refactored `getNormalizedUrl` to return an additional param `searchParamEntries` which is key pair object of all query params.

Refactored `matchMock` to uses the new `searchParamEntries` returned by `getNormalizedUrl` and calls the search mockData `searchFunc` if it is defined.



