### PR TITLE
feat: allow to pass response function

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ There are few packages those help the developers to mock the backend requests wh
 
 | Property   | Description                                                                                 | Required | Default |
 | ---------- | :------------------------------------------------------------------------------------------ | :------- | :------ |
-| `url`      | Supports both **named parameters** (`/:foo/:bar`) and **query parameters**(`/foo?bar=true`) | Y        |     -    |
-| `method`   | Supports `GET`, `POST` and `PUT` methods                                                    |    -      | `GET`   |
-| `status`   | All possible HTTP status codes                                                              |    -      | `200`   |
-| `response` | JSON format                                                                                 | Y        |     -    |
-| `delay`    | Emulate delayed response time in milliseconds                                               |      -    | `0`     |
+| `url`      | Supports both **named parameters** (`/:foo/:bar`) and **query parameters**(`/foo?bar=true`) | Y        |    -    |
+| `method`   | Supports `GET`, `POST` and `PUT` methods                                                    |     -    | `GET`   |
+| `status`   | All possible HTTP status codes                                                              |     -    | `200`   |
+| `response` | JSON format or function `({ url: string, method: string, body: string | null }) => JSON`    | Y        |    -    |
+| `delay`    | Emulate delayed response time in milliseconds                                               |     -    | `0`     |
 
 > You can change the **status**, **response** and **delay** from the storybook panel on the fly! :rocket:
 
@@ -107,6 +107,38 @@ storiesOf('Mock Response Story', module)
             },
         ],
     });
+```
+
+### Custom Response
+
+```js
+import React from 'react';
+import withMock from 'storybook-addon-mock';
+import Component from './Component';
+
+export default {
+    title: 'Component',
+    component: Component,
+    decorators: [withMock],
+};
+
+const Template = (args) => <Component {...args} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+    mockData: [
+        {
+            url: 'https://jsonplaceholder.typicode.com/todos/1',
+            method: 'GET',
+            status: 200,
+            response: (req) => {
+                return {
+                    data: `Hello ${JSON.parse(req).name}`,
+                };
+            },
+        },
+    ],
+};
 ```
 
 ## User guide

--- a/src/components/RequestItem/index.js
+++ b/src/components/RequestItem/index.js
@@ -98,34 +98,38 @@ export const RequestItem = ({
             </div>
             <div style={rowStyles}>
                 <Field label="Response">
-                    <JSONInput
-                        name="response"
-                        locale={enLocale}
-                        onBlur={(value) =>
-                            onFieldChange(value.jsObject, 'response')
-                        }
-                        placeholder={response}
-                        colors={{
-                            default: 'black',
-                            background: 'white',
-                            string: 'black',
-                            number: 'black',
-                            colon: 'black',
-                            keys: 'black',
-                            error: 'black',
-                        }}
-                        style={{
-                            warningBox: {
+                    {typeof response === 'function' ? (
+                        response.toString()
+                    ) : (
+                        <JSONInput
+                            name="response"
+                            locale={enLocale}
+                            onBlur={(value) =>
+                                onFieldChange(value.jsObject, 'response')
+                            }
+                            placeholder={response}
+                            colors={{
+                                default: 'black',
                                 background: 'white',
-                            },
-                            body: {
-                                fontFamily: 'inherit',
-                                fontSize: '12px',
-                            },
-                        }}
-                        waitAfterKeyPress={1000}
-                        height="120px"
-                    />
+                                string: 'black',
+                                number: 'black',
+                                colon: 'black',
+                                keys: 'black',
+                                error: 'black',
+                            }}
+                            style={{
+                                warningBox: {
+                                    background: 'white',
+                                },
+                                body: {
+                                    fontFamily: 'inherit',
+                                    fontSize: '12px',
+                                },
+                            }}
+                            waitAfterKeyPress={1000}
+                            height="120px"
+                        />
+                    )}
                 </Field>
                 <Field />
             </div>
@@ -139,7 +143,11 @@ RequestItem.propTypes = {
     method: PropTypes.string,
     delay: PropTypes.number,
     status: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-    response: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+    response: PropTypes.oneOfType([
+        PropTypes.object,
+        PropTypes.array,
+        PropTypes.func,
+    ]),
     onToggle: PropTypes.func,
     onFieldChange: PropTypes.func,
 };

--- a/src/utils/faker.js
+++ b/src/utils/faker.js
@@ -118,7 +118,11 @@ export class Faker {
             const { response, status, delay = 0 } = matched;
             return new Promise((resolve) => {
                 setTimeout(() => {
-                    resolve(new Response(url, status, response));
+                    if (typeof response === 'function') {
+                        resolve(new Response(url, status, response(request)));
+                    } else {
+                        resolve(new Response(url, status, response));
+                    }
                 }, +delay);
             });
         }
@@ -132,7 +136,14 @@ export class Faker {
         if (matched) {
             const { response, status, delay = 0 } = matched;
             setTimeout(() => {
-                xhr.respond(+status, {}, response);
+                if (typeof response === 'function') {
+                    const data = response(
+                        new Request(url, { method, body: xhr.body })
+                    );
+                    xhr.respond(status, {}, data);
+                } else {
+                    xhr.respond(+status, {}, response);
+                }
             }, +delay);
         } else {
             // eslint-disable-next-line new-cap

--- a/src/utils/request.js
+++ b/src/utils/request.js
@@ -2,8 +2,10 @@ export function Request(input, options = {}) {
     if (typeof input === 'object') {
         this.method = options.method || input.method || 'GET';
         this.url = input.url;
+        this.body = options.body || input.body || null;
     } else {
         this.method = options.method || 'GET';
         this.url = input;
+        this.body = options.body || null;
     }
 }

--- a/stories/example.stories.js
+++ b/stories/example.stories.js
@@ -99,6 +99,68 @@ const callAxios = async () => {
     };
 };
 
+const callPostFetch = async () => {
+    let data = null;
+    let error = null;
+    let status = null;
+
+    try {
+        const response = await fetch(
+            'https://jsonplaceholder.typicode.com/todos/1',
+            {
+                headers: {
+                    Accept: 'application/json',
+                    'Content-Type': 'application/json',
+                },
+                method: 'POST',
+                body: JSON.stringify({
+                    name: 'foo',
+                }),
+            }
+        );
+        const responseData = await response.json();
+
+        if (response.ok) {
+            data = responseData;
+        } else {
+            error = responseData;
+        }
+        status = response.status;
+    } catch (err) {
+        // eslint-disable-next-line no-console
+        console.log(err);
+        error = err;
+    }
+    return {
+        data,
+        error,
+        status,
+    };
+};
+
+const callPostAxios = async () => {
+    let data = null;
+    let error = null;
+    let status = null;
+
+    try {
+        const response = await axios.post(
+            'https://jsonplaceholder.typicode.com/todos/1',
+            { name: 'foo' }
+        );
+        data = response.data;
+        status = response.status;
+    } catch (err) {
+        error = err.response.data;
+        status = err.response.status;
+    }
+    return {
+        data,
+        error,
+        status,
+    };
+};
+
 const MockExample = ({ title, onRequest }) => {
     const [response, setResponse] = useState({});
     const [loading, setLoading] = useState(false);
@@ -161,6 +223,18 @@ const mockData = [
     },
 ];
 
+const mockPostData = [
+    {
+        url: 'https://jsonplaceholder.typicode.com/todos/:id',
+        method: 'POST',
+        status: 200,
+        delay: 0,
+        response: (req) => {
+            return { data: `Hello ${JSON.parse(req.body).name}` };
+        },
+    },
+];
+
 storiesOf('Storybook-addon-mock', module)
     .addDecorator(withMock)
     .add(
@@ -172,4 +246,14 @@ storiesOf('Storybook-addon-mock', module)
         'Axios request',
         () => <MockExample title="Axios(XHR)" onRequest={callAxios} />,
         { mockData }
+    )
+    .add(
+        'POST Fetch request',
+        () => <MockExample title="Fetch" onRequest={callPostFetch} />,
+        { mockData: mockPostData }
+    )
+    .add(
+        'POST Axios request',
+        () => <MockExample title="Axios(XHR)" onRequest={callPostAxios} />,
+        { mockData: mockPostData }
     );


### PR DESCRIPTION
**Changes:**

Allow `response` to be a function. This is useful to be able to mock same API call returning different value when using `POST` requests.