### PR TITLE
Avoid installing storybook/react for projects using the addon

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,10 +34,15 @@
   "license": "MIT",
   "dependencies": {
     "@storybook/addons": "^6.2.9",
-    "@storybook/react": "^6.2.9",
+    "@storybook/api": "^6.2.9",
+    "@storybook/components": "^6.2.9",
     "mock-xmlhttprequest": "^7.0.3",
     "path-to-regexp": "^6.2.0",
     "react-json-editor-ajrm": "^2.5.13"
+  },
+  "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.13.10",
@@ -46,6 +51,7 @@
     "@babel/plugin-transform-modules-commonjs": "^7.13.8",
     "@babel/preset-env": "^7.13.12",
     "@babel/preset-react": "^7.12.13",
+    "@storybook/react": "^6.2.9",
     "@storybook/storybook-deployer": "^2.8.10",
     "axios": "^0.21.1",
     "babel-eslint": "^10.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2146,7 +2146,7 @@
     global "^4.4.0"
     regenerator-runtime "^0.13.7"
 
-"@storybook/api@6.2.9":
+"@storybook/api@6.2.9", "@storybook/api@^6.2.9":
   version "6.2.9"
   resolved "https://registry.yarnpkg.com/@storybook/api/-/api-6.2.9.tgz#a9b46569192ad5d8da6435c9d63dc4b0c8463b51"
   integrity sha512-okkA3HAScE9tGnYBrjTOcgzT+L1lRHNoEh3ZfGgh1u/XNEyHGNkj4grvkd6nX7BzRcYQ/l2VkcKCqmOjUnSkVQ==
@@ -2302,7 +2302,7 @@
     core-js "^3.8.2"
     global "^4.4.0"
 
-"@storybook/components@6.2.9":
+"@storybook/components@6.2.9", "@storybook/components@^6.2.9":
   version "6.2.9"
   resolved "https://registry.yarnpkg.com/@storybook/components/-/components-6.2.9.tgz#7189f9715b05720fe083ae8ad014849f14e98e73"
   integrity sha512-hnV1MI2aB2g1sJ7NJphpxi7TwrMZQ/tpCJeHnkjmzyC6ez1MXqcBXGrEEdSXzRfAxjQTOEpu6H1mnns0xMP0Ag==


### PR DESCRIPTION
This makes it better when using this addon in a different storybook app.

This also defines all the dependencies of the addon instead of relying on transitive dependencies that may not be available when using yarn in PnP mode. This follows what official addons are doing.