### PR TITLE
fix(response): fix Response.text return value

### DIFF
--- a/src/utils/response.js
+++ b/src/utils/response.js
@@ -10,7 +10,12 @@ export function Response(url, status, responseText) {
     this.status = status;
     this.url = url;
 
-    this.text = () => Promise.resolve(responseText);
+    this.text = () =>
+        Promise.resolve(
+            typeof responseText === 'string'
+                ? responseText
+                : JSON.stringify(responseText)
+        );
     this.json = () => Promise.resolve(responseText);
     (this.clone = () => new Response(url, status, responseText)),
         (this.headers = {


### PR DESCRIPTION
Response.text should always return a string. In case the passed value is already a string, don't run
it through JSON.parse, since that would wrap the string in extra quotes.

fix https://github.com/nutboltu/storybook-addon-mock/issues/89