### PR TITLE
Update mock-xmlhttprequest dependency to 8.1.0

### DIFF
--- a/packages/mock-addon/package.json
+++ b/packages/mock-addon/package.json
@@ -44,7 +44,7 @@
     "release": "yarn build && auto shipit"
   },
   "dependencies": {
-    "mock-xmlhttprequest": "^7.0.3",
+    "mock-xmlhttprequest": "^8.1.0",
     "path-to-regexp": "^6.2.0",
     "polished": "^4.2.2"
   },

--- a/packages/mock-addon/src/utils/faker.js
+++ b/packages/mock-addon/src/utils/faker.js
@@ -133,21 +133,21 @@ export class Faker {
         return global.realFetch(input, options);
     };
 
-    mockXhrRequest = (xhr) => {
-        const { method, url, body } = xhr;
+    mockXhrRequest = (request) => {
+        const { method, url, body } = request;
         const matched = this.matchMock(url, method);
         if (matched) {
             const { response, status, delay = 0 } = matched;
             setTimeout(() => {
                 if (typeof response === 'function') {
                     const data = response(new Request(url, { method, body }));
-                    xhr.respond(
+                    request.respond(
                         +status,
                         defaultResponseHeaders,
                         JSON.stringify(data)
                     );
                 } else {
-                    xhr.respond(
+                    request.respond(
                         +status,
                         defaultResponseHeaders,
                         JSON.stringify(response)
@@ -159,12 +159,15 @@ export class Faker {
             const realXhr = new global.realXMLHttpRequest();
             realXhr.open(method, url);
 
-            setRequestHeaders(realXhr, xhr.requestHeaders._headers);
-            realXhr.withCredentials = xhr._withCredentials;
+            setRequestHeaders(
+                realXhr,
+                new Map(Object.entries(request.requestHeaders.getHash()))
+            );
+            realXhr.withCredentials = request.withCredentials;
 
             realXhr.onreadystatechange = function onReadyStateChange() {
                 if (realXhr.readyState === 4 && realXhr.status === 200) {
-                    xhr.respond(
+                    request.respond(
                         200,
                         getResponseHeaderMap(realXhr),
                         realXhr.responseText

--- a/yarn.lock
+++ b/yarn.lock
@@ -10214,10 +10214,10 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   resolved "https://packages.atlassian.com/api/npm/npm-remote/mkdirp/-/mkdirp-1.0.4.tgz"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-mock-xmlhttprequest@^7.0.3:
-  version "7.0.4"
-  resolved "https://packages.atlassian.com/api/npm/npm-remote/mock-xmlhttprequest/-/mock-xmlhttprequest-7.0.4.tgz#5e188da009cf46900e522f690cbea8d26274a872"
-  integrity sha512-hA0fIHy/74p5DE0rdmrpU0sV1U+gnWTcgShWequGRLy0L1eT+zY0ozFukawpLaxMwIA+orRcqFRElYwT+5p81A==
+mock-xmlhttprequest@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/mock-xmlhttprequest/-/mock-xmlhttprequest-8.1.0.tgz#b5bfac136f85b29f96cfb446c0d16e8dee04aef5"
+  integrity sha512-hOpjaDRdWQTscwOME6W50OTT9duY1hm8w7Nx3i5GE35OHseiR3Z2s2Azy1BhpY7dUioiNiL0bs7dfEla3siRnw==
 
 module-alias@^2.2.2:
   version "2.2.2"


### PR DESCRIPTION
I'm the author of mock-xmlhttprequest so I'm submitting the necessary changes to upgrade this dependency to the latest version that has a number of [bug fixes and improvements](https://github.com/berniegp/mock-xmlhttprequest/releases).

I ran the unit tests in the project, but I don't use this library so I could have missed something. Also, I noticed that `packages\mock-addon\src\utils\faker.test.js` doesn't seem to test the code path I modified.