### PR TITLE
feat: allow string responses

### DIFF
--- a/packages/mock-addon-docs/stories/docs/installation-setup.stories.mdx
+++ b/packages/mock-addon-docs/stories/docs/installation-setup.stories.mdx
@@ -85,7 +85,7 @@ Each mock object contains the following properties.
 | `url`      | Supports both **named parameters** (`/:foo/:bar`) and **query parameters**.(`/foo?bar=true`) | true        |    -    |
 | `method`   | Supports `GET`, `POST`, `PUT`, `PATCH` and `DELETE` methods.                                                   |    true    | - |
 | `status`   | All possible [HTTP status codes](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status).                                                              |     true   |  -  |
-| `response` | A valid JSON format(Array or Object) or function. <br/> Response function is a function that contains request object as a parameter. See the **Custom Response** section for example.  | true        |    -    |
+| `response` | A valid JSON format(Array or Object), function or string. <br/> Response function is a function that contains request object as a parameter. See the **Custom Response** section for example.  | true        |    -    |
 | `delay`    | Emulate delayed response time in milliseconds.                                              |     -    | `0`     |
 
 

--- a/packages/mock-addon/src/utils/headers.js
+++ b/packages/mock-addon/src/utils/headers.js
@@ -21,3 +21,7 @@ export function getResponseHeaderMap(xhr) {
 export const defaultResponseHeaders = {
     'content-type': 'application/json',
 };
+
+export const textResponseHeaders = {
+    'content-type': 'text/plain',
+};

--- a/packages/mock-addon/src/utils/response.js
+++ b/packages/mock-addon/src/utils/response.js
@@ -1,6 +1,6 @@
 import 'whatwg-fetch';
 import statusTextMap from './statusMap';
-import { defaultResponseHeaders } from './headers';
+import { defaultResponseHeaders, textResponseHeaders } from './headers';
 
 export function CustomResponse(url, status, responseText) {
     const text =
@@ -13,7 +13,9 @@ export function CustomResponse(url, status, responseText) {
         status: status,
         statusText: statusTextMap[status.toString()],
         headers: new Headers({
-            ...defaultResponseHeaders,
+            ...(typeof responseText === 'string'
+                ? textResponseHeaders
+                : defaultResponseHeaders),
         }),
         url,
     });

--- a/packages/mock-addon/src/utils/response.test.js
+++ b/packages/mock-addon/src/utils/response.test.js
@@ -21,8 +21,10 @@ describe('CustomResponse', () => {
     });
     it('should return text as a string if responseText is string', async () => {
         const response = new CustomResponse(mockURL, 200, 'This is a string');
-        const actual = await response.text();
-        expect(actual).toEqual('This is a string');
+        const actualText = await response.text();
+        const actualContentType = await response.headers.get("content-type");
+        expect(actualText).toEqual('This is a string');
+        expect(actualContentType).toEqual('text/plain')
     });
     it('should return text as a string if responseText is an object', async () => {
         const response = new CustomResponse(mockURL, 200, { key: 'test' });

--- a/packages/mock-addon/src/utils/response.test.js
+++ b/packages/mock-addon/src/utils/response.test.js
@@ -22,9 +22,9 @@ describe('CustomResponse', () => {
     it('should return text as a string if responseText is string', async () => {
         const response = new CustomResponse(mockURL, 200, 'This is a string');
         const actualText = await response.text();
-        const actualContentType = await response.headers.get("content-type");
+        const actualContentType = await response.headers.get('content-type');
         expect(actualText).toEqual('This is a string');
-        expect(actualContentType).toEqual('text/plain')
+        expect(actualContentType).toEqual('text/plain');
     });
     it('should return text as a string if responseText is an object', async () => {
         const response = new CustomResponse(mockURL, 200, { key: 'test' });

--- a/packages/mock-addon/src/utils/validator.js
+++ b/packages/mock-addon/src/utils/validator.js
@@ -25,7 +25,7 @@ export const schema = {
         return (
             (isObject(value) ||
                 Array.isArray(value) ||
-                value === 'string' ||
+                typeof value === 'string' ||
                 typeof value === 'function') &&
             value !== null
         );

--- a/packages/mock-addon/src/utils/validator.js
+++ b/packages/mock-addon/src/utils/validator.js
@@ -25,6 +25,7 @@ export const schema = {
         return (
             (isObject(value) ||
                 Array.isArray(value) ||
+                value === 'string' ||
                 typeof value === 'function') &&
             value !== null
         );

--- a/packages/mock-addon/src/utils/validator.test.js
+++ b/packages/mock-addon/src/utils/validator.test.js
@@ -52,7 +52,7 @@ describe('Validator', () => {
             expect(actual).toEqual([]);
         });
 
-        it('should return rul error array if url is not a string', () => {
+        it('should return url error array if url is not a string', () => {
             const mock = {
                 url: {},
                 method: 'GET',
@@ -204,7 +204,7 @@ describe('Validator', () => {
             expect(actual).toEqual([]);
         });
 
-        it('should return not valid response error if response is a string', () => {
+        it('should return empty error if response is a string', () => {
             const mock = {
                 url: 'https://jsonplaceholder.typicode.com/todos/:id',
                 method: 'GET',
@@ -213,7 +213,7 @@ describe('Validator', () => {
                 response: 'string',
             };
             const actual = validate(mock, schema);
-            expect(actual).toEqual(['response: "string" is not valid.']);
+            expect(actual).toEqual([]);
         });
 
         it('should return not valid response error if response is null', () => {

--- a/packages/mock-addon/src/utils/validator.test.js
+++ b/packages/mock-addon/src/utils/validator.test.js
@@ -210,7 +210,7 @@ describe('Validator', () => {
                 method: 'GET',
                 status: 200,
                 delay: 0,
-                response: 'string',
+                response: 'a string value',
             };
             const actual = validate(mock, schema);
             expect(actual).toEqual([]);


### PR DESCRIPTION
I've added the support for returning a string value in a response instead of only allowing JSON. Adding the change to the Storybook docs in `packages/mock-addon-docs` requires some bigger changes in the test files, so I haven't done that yet because I wanted to wait for your feedback on whether you want to accept the PR and if so, how it should be added to the docs.

Closes #200 .